### PR TITLE
MAJ Fiche COC V2.7

### DIFF
--- a/coc.html
+++ b/coc.html
@@ -31,11 +31,14 @@
   <input type="hidden" name="attr_INIT_BUFF" value="0" />
   <input type="hidden" name="attr_DEF_BUFF" value="0" />
   <input type="hidden" name="attr_DEP_BUFF" value="0" />
+  <input type="hidden" name="attr_PV_BUFF" value="0" />
   <!-- INPUT HIDDEN Précédent état préjudiciable -->
   <input type="hidden" name="attr_CONDITION" value="" />
   <input type="hidden" name="attr_PCONDITION" value="" />
   <!-- INPUT HIDDEN Précédent nombre de PV -->
   <input type="hidden" name="attr_LAST_PV" value="" />
+  <!-- INPUT HIDDEN PV par niveau -->
+  <input type="hidden" name="attr_PV_NIVEAU" value="" />
   <!-- INPUT HIDDEN Choix carac jets capacités -->
   <input type="hidden" name="attr_QRYMOD" value="?{Carac. ?|Force,@{FOR}|Dextérité,@{DEX}|Constitution,@{CON}|Intelligence,@{INT}|Perception,@{PER}|Charisme,@{CHA}}" />
   <input type="hidden" name="attr_QRYMODT" value="?{Carac. ?|Force,@{FOR_TEST}|Dextérité,@{DEX_TEST}|Constitution,@{CON_TEST}|Intelligence,@{INT_TEST}|Perception,@{PER_TEST}|Charisme,@{CHA_TEST}}" />
@@ -492,8 +495,9 @@
                         <td class="sheet-textfat">&nbsp;</td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="JET_DV" title="Jet de Dé de Vie" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dé de Vie}} {{subtags=Vitalité}} {{DV=[[ 1d@{DV}[Dé de Vie] + [[@{CON}]][CON] ]]}}"> DV</button>
+                        <td class="sheet-boxtitre"> <!--
+                          <button class="sheet-boxtitre" type="roll" name="JET_DV" title="Jet de Dé de Vie" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dé de Vie}} {{subtags=Vitalité}} {{DV=[[ 1d@{DV}[Dé de Vie] + [[@{CON}]][CON] ]]}}"> DV</button> -->
+                          <button class="sheet-boxtitre" type="action" name="act_dv" title="Progression d'un niveau"> DV</button>
                         </td>
                         <td class="sheet-boxinput">
                           <select class="sheet-carac" name="attr_DV" size="1" title="@{DV} Dé de Vie">
@@ -1245,6 +1249,13 @@
               <span class="textbase">Encombrement</span>&nbsp;
               <input type="checkbox" name="attr_use_encombrement" title="@{use_encombrement} Gérer l'encombrement" value="1" />
             </td>
+            <td>
+              <span class="textbase">Progression PV :</span>&nbsp;
+              <select class="sheet-carac" style="width: 90px;" name="attr_prog_pv" title="@{prog_pv}" size="1">
+                <option value="0" selected>Jet DV</option>
+                <option value="1">Moyenne</option>
+              </select>
+            </td>
           </tr>
         </table>
       </div>
@@ -1360,6 +1371,15 @@
             </td>
             <td style="width: 5%;">
               <input class="sheet-buff" type="number" name="attr_DEF_BUFFS" value="@{DEF_BUFF}" disabled />
+            </td>
+          </tr>
+          <tr>
+            <td style="width: 5%;">PV:</td>
+            <td style="width: 90%;">
+              <input class="sheet-buff" type="text" name="attr_PV_BUFF_LIST" placeholder="<Type> : <Valeur>; <Type> <Valeur>..." />
+            </td>
+            <td style="width: 5%;">
+              <input class="sheet-buff" type="number" name="attr_PV_BUFFS" value="@{PV_BUFF}" disabled />
             </td>
           </tr>
         </table>
@@ -1913,6 +1933,12 @@
     console.log('** CO sheetworker' + m + ' <<<');
     console.log(l);
     console.log('** CO sheetworker' + m + ' >>>');
+  }
+  
+  function getRandom(max) {
+    let min = 1;
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min +1)) + min;
   }
 
   function addTrait(npcObj, traitObj) {
@@ -2525,6 +2551,10 @@
 
   on('change:def_buff_list', function() {
     parseBuff('DEF');
+  });
+
+  on('change:pv_buff_list', function() {
+    parseBuff('PV');
   });
   
   on('change:blessure', function() {
@@ -3199,6 +3229,77 @@
         PCONDITION: condition,
         conditions: displayConditions
       });
+    });
+  });
+  
+  function hitPoints(attr) {
+    getAttrs(['NIVEAU', 'DV', 'CONSTITUTION', 'PV_NIVEAU', 'PV_BUFF', 'prog_pv'], function(values) {
+      let niveau = parseInt(values.NIVEAU) || 0;
+      if (niveau === 0) return;
+      let dv = parseInt(values.DV) || 0;
+      if (dv === 0) return;
+      let constitution = parseInt(values.CONSTITUTION) || 0;
+      let modcon = 0;
+      if (constitution > 0) modcon = Math.floor((constitution - 10) / 2);
+      let pv_niveau = values.PV_NIVEAU || '';
+      let pv = [];
+      if (attr === 'niveau' || attr === 'constitution' || attr === 'pv_buff') {
+        if (pv_niveau !== '') pv = JSON.parse(pv_niveau);
+      }
+      let average = (parseInt(values.prog_pv) || 0 === 1) ? 1 + (dv / 2) : 0;
+      let pv_buff = parseInt(values.PV_BUFF) || 0;
+      let pv_max = 0;
+      for (let n = 1; n <= niveau; n++) {
+        let pvie = 0;
+        if (n === 1) {
+          pvie = dv + modcon; // niveau 1 : Max. DV + Mod. CON
+        } else {
+          if (n > 10) { // niveaux > 10 : 1 ou 2 PV selon DV
+            if (dv >= 10) pvie = 2;
+            else pvie = 1;
+          } else { // niveaux <= 10
+            if (n % 2 === 0) { // niveau pair
+              if (n > pv.length) { // nouveau niveau
+                if (average !== 0) {
+                  pvie = average; // ... soit moyenne du DV + 1
+                } else {
+                  pvie = getRandom(dv); // ... soit tirage de DV
+                }
+                if (modcon < 0) pvie += modcon; // ... + Mod. CON si négative
+                if (pvie < 0) pvie = 0; // ... mais on ne perd pas de PV
+              } else { // niveau existant
+                pvie = pv[n - 1];
+              }
+            } else { // niveau impair
+              if (modcon > 0) pvie = modcon; // Mod. CON si positif
+            }
+          }
+        }
+        if (n > pv.length) pv.push(pvie);
+        else pv[n - 1] = pvie;
+        pv_max += pvie;
+      }
+      pv_max += pv_buff;
+      setAttrs({
+        PV_NIVEAU: JSON.stringify(pv),
+        PV_max: pv_max,
+        PV: pv_max
+      });
+    });
+  }
+  
+  on('change:niveau change:dv change:constitution change:pv_buff change:prog_pv', function(eventInfo) {
+    hitPoints(eventInfo.sourceAttribute);
+  });
+  
+  on('clicked:dv', function() {
+    getAttrs(['NIVEAU'], function(value) {
+      let niveau = parseInt(value.NIVEAU) || 0;
+      if (niveau > 0 && niveau <=20) {
+        setAttrs({
+          NIVEAU: niveau + 1
+        });
+      }
     });
   });
 

--- a/coc.html
+++ b/coc.html
@@ -158,7 +158,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_for" title="Jet de Force" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_for" title="%{jet_for} Jet de Force" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_FOR_SUP" title="@{FOR_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -182,7 +182,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_dex" title="Jet de Dextérité" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]]}}"> DEX</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_dex" title="%{jet_dex} Jet de Dextérité" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]]}}"> DEX</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_DEX_SUP" title="@{DEX_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -206,7 +206,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_con" title="Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]]}}"> CON</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_con" title="%{jet_con} Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]]}}"> CON</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_CON_SUP" title="@{CON_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -230,7 +230,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_int" title="Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]]}}"> INT</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_int" title="%{jet_int} Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]]}}"> INT</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_INT_SUP" title="@{INT_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -254,7 +254,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_per" title="Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]]}}"> PER</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_per" title="%{jet_per} Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]]}}"> PER</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_PER_SUP" title="@{PER_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -278,7 +278,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="roll_jet_cha" title="Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]]}}"> CHA</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_cha" title="%{jet_cha} Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]]}}"> CHA</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_CHA_SUP" title="@{CHA_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -373,7 +373,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_jet_cac" title="Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]]}}"> AU CONTACT</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_cac" title="%{jet_cac} Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]]}}"> AU CONTACT</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKCAC_BASE" value="0" title="@{ATKCAC_BASE} Score de base" />
@@ -397,7 +397,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_jet_tir" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]]}}"> &Agrave; DISTANCE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_tir" title="%{jet_tir} Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]]}}"> &Agrave; DISTANCE</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKTIR_BASE" value="0" title="@{ATKTIR_BASE} Score de base" />
@@ -421,7 +421,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_jet_men" title="Jet d'attaque mentale" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Mental}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMEN}]][Bonus] ]]}}"> MENTAL</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_men" title="%{jet_men} Jet d'attaque mentale" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Mental}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMEN}]][Bonus] ]]}}"> MENTAL</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKMEN_BASE" value="0" title="@{ATKMEN_BASE} Score de base" />
@@ -445,7 +445,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_jet_mag" title="Jet d'attaque magique" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Magique}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMAG}]][Bonus] ]]}}"> MAGIQUE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_mag" title="%{jet_mag} Jet d'attaque magique" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Magique}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMAG}]][Bonus] ]]}}"> MAGIQUE</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKMAG_BASE" value="0" title="@{ATKMAG_BASE} Score de base" />
@@ -469,10 +469,10 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_jet_init" title="@{JET_INIT} Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT_JET} &{tracker}]]}}"> INITIATIVE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_init" title="%{jet_init} Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT_JET} &{tracker}]]}}"> INITIATIVE</button>
                         </td>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="roll_next_init" title="@{NEXT_INIT} Actions multiples si jet d'Init > 20, 30, etc..." value="@{togm}&{template:co1} {{perso=@{selected|character_name}}} {{subtags=Initiative}} {{name=Action suivante}} {{desc=(A)ction / (M)ouvement à Init-[[10 &{tracker:-}]]}}"> Suite</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_next_init" title="%{next_init} Actions multiples si jet d'Init > 20, 30, etc..." value="@{togm}&{template:co1} {{perso=@{selected|character_name}}} {{subtags=Initiative}} {{name=Action suivante}} {{desc=(A)ction / (M)ouvement à Init-[[10 &{tracker:-}]]}}"> Suite</button>
                         </td>
                         <td class="sheet-boxinputlight">
                           <input type="number" name="attr_INIT_CARAC" title="@{INIT_CARAC}" value="@{DEXTERITE}" disabled />
@@ -621,7 +621,7 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td>
-                    <button type="roll" class="sheet-neutre" name="roll_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
+                    <button type="roll" class="sheet-neutre" name="roll_jet" title="%{repeating_armes_$N_jet}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
                     <!-- original : "@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}  @{armelim}}} {{portee=@{armeportees}}} {{desc=@{armejetn}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + ([[@{visee_att}]])[Tir visé] + ([[@{distance}]])[Portée] ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + ([[@{visee_dm}]])[Tir visé] ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" -->
                   </td>
                   <td class="sheet-boxinputleft" style="min-width:125px;">
@@ -1024,7 +1024,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td>
-                <button type="roll" class="sheet-neutre" name="roll_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
+                <button type="roll" class="sheet-neutre" name="roll_jet" title="%{repeating_jet_capas_$N_jet}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
               </td>
               <td class="sheet-boxinputleft" style="min-width:200px;">
                 <input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;" placeholder="Nom du Jet de capacité" />
@@ -1102,7 +1102,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td style="width: 15px;">
-                <button type="roll" name="roll_trait" class="sheet-output" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
+                <button type="roll" name="roll_trait" class="sheet-output" title="%{repeating_traits_$N_trait}" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
               </td>
               <td class="sheet-boxinputleft" style="width: 200px;">
                 <input type="text" style="font-weight: bold;" name="attr_traitnom" placeholder="Nom du trait" title="@{traitnom}" />
@@ -1146,10 +1146,10 @@
             <table class="sheet-tabsep">
               <tr>
                 <td class="sheet-boxtitre">
-                  <button type="roll" class="sheet-boxtitre" title="Utilisation d'un PC" name="roll_jet_pc" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{PC_DESC}}} {{subtags=Bonus}} {{desc=@{character_name} utilise un @{PC_DESC} et obtient un bonus de @{PC_BONUS}}}" /> PC
+                  <button type="roll" class="sheet-boxtitre" title="%{jet_pc} Utilisation d'un PC" name="roll_jet_pc" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{PC_DESC}}} {{subtags=Bonus}} {{desc=@{character_name} utilise un @{PC_DESC} et obtient un bonus de @{PC_BONUS}}}" /> PC
                 </td>
                 <td class="sheet-boxtitre">
-                  <button type="roll" class="sheet-boxtitre" title="Jet de Récupération" name="roll_jet_pr" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalité}} {{DV=[[1d@{DV}[Dé de Vie] +[[@{CON}]][CON] +@{NIVEAU}[Niveau] ]]}}" /> PR</td>
+                  <button type="roll" class="sheet-boxtitre" title="%{jet_pr} Jet de Récupération" name="roll_jet_pr" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalité}} {{DV=[[1d@{DV}[Dé de Vie] +[[@{CON}]][CON] +@{NIVEAU}[Niveau] ]]}}" /> PR</td>
                 <td class="sheet-boxtitre">PM</td>
               </tr>
               <tr>
@@ -1393,7 +1393,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td class="sheet-boxtitre">
-                <button class="sheet-boxtitre" type="roll" name="roll_jet_psi" title="Jet d'attaque PSI" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=PSI}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSI}]][Bonus] ]]}}"> Attaque PSI</button>
+                <button class="sheet-boxtitre" type="roll" name="roll_jet_psi" title="%{jet_psi} Jet d'attaque PSI" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=PSI}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSI}]][Bonus] ]]}}"> Attaque PSI</button>
               </td>
               <td class="sheet-boxinput">
                 <input type="number" name="attr_ATKPSI_BASE" value="0" title="@{ATKPSI_BASE}" />
@@ -1482,7 +1482,7 @@
         <table class="sheet-tabsep">
           <tr>
             <td>
-              <button type="roll" class="sheet-neutre" name="roll_jetv" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetvnom}}} {{subtags=@{VEHICULE}}} {{carac=[[@{jetvnbde}d@{jetvde}@{jetvtypjet} + [[@{jetvcaracp}]][Bonus] + [[@{jetvcarac}]][Véhicule] + @{jetvdiv}[Divers] ]]}} {{desc=@{jetvdesc}}}" />
+              <button type="roll" class="sheet-neutre" name="roll_jetv" title="%{repeating_jetv_$N_jet_v} Jet de véhicule" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetvnom}}} {{subtags=@{VEHICULE}}} {{carac=[[@{jetvnbde}d@{jetvde}@{jetvtypjet} + [[@{jetvcaracp}]][Bonus] + [[@{jetvcarac}]][Véhicule] + @{jetvdiv}[Divers] ]]}} {{desc=@{jetvdesc}}}" />
             </td>
             <td class="sheet-boxinputleft" style="min-width:200px;">
               <input type="text" name="attr_jetvnom" title="@{jetvnom}" style="font-weight: bold;" placeholder="Nom du Jet de véhicule" />
@@ -1564,7 +1564,7 @@
             <div class="sheet-3colrow">
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_for" title="Jet de Force" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{pnj_jetfor}cs20cf1[Dé] + [[@{pnj_for}]][FOR] ]] }}"> FOR</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_for" title="%{pnj_for} Jet de Force" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{pnj_jetfor}cs20cf1[Dé] + [[@{pnj_for}]][FOR] ]] }}"> FOR</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_for" type="number" title="@{pnj_for}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetfor" title="@{pnj_jetfor}">
@@ -1575,7 +1575,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_dex" title="Jet de Dextérité" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{pnj_jetdex}cs20cf1[Dé] + [[@{pnj_dex}]][DEX] ]] }}"> DEX</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_dex" title="%{pnj_dex} Jet de Dextérité" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{pnj_jetdex}cs20cf1[Dé] + [[@{pnj_dex}]][DEX] ]] }}"> DEX</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_dex" type="number" title="@{pnj_dex}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetdex" title="@{pnj_jetdex}">
@@ -1586,7 +1586,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_con" title="Jet de Constitution" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{pnj_jetcon}cs20cf1[Dé] + [[@{pnj_con}]][CON] ]] }}"> CON</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_con" title="%{pnj_con} Jet de Constitution" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{pnj_jetcon}cs20cf1[Dé] + [[@{pnj_con}]][CON] ]] }}"> CON</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_con" type="number" title="@{pnj_con}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetcon" title="@{pnj_jetcon}">
@@ -1600,7 +1600,7 @@
             <div class="sheet-3colrow">
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_int" title="Jet d'Intelligence" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{pnj_jetint}cs20cf1[Dé] + [[@{pnj_int}]][INT] ]] }}"> INT</div>
+                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_int" title="%{pnj_int} Jet d'Intelligence" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{pnj_jetint}cs20cf1[Dé] + [[@{pnj_int}]][INT] ]] }}"> INT</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_int" type="number" title="@{pnj_int}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetint" title="@{pnj_jetint}">
@@ -1611,7 +1611,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_per" title="Jet de Perception" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{pnj_jetper}cs20cf1[Dé] + [[@{pnj_per}]][PER] ]] }}"> PER</div>
+                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_per" title="%{pnj_per} Jet de Perception" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{pnj_jetper}cs20cf1[Dé] + [[@{pnj_per}]][PER] ]] }}"> PER</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_per" type="number" title="@{pnj_per}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetper" title="@{pnj_jetper}">
@@ -1622,7 +1622,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_cha" title="Jet de Charisme" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{pnj_jetcha}cs20cf1[Dé] + [[@{pnj_cha}]][CHA] ]] }}"> CHA</div>
+                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_cha" title="%{pnj_cha} Jet de Charisme" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{pnj_jetcha}cs20cf1[Dé] + [[@{pnj_cha}]][CHA] ]] }}"> CHA</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_cha" type="number" title="@{pnj_cha}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetcha" title="@{pnj_jetcha}">
@@ -1636,7 +1636,7 @@
             <div class="sheet-3colrow">
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_init" title="Jet d'Initiative" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init}[Init.] + @{pnj_init_var}[Dé(s)] &{tracker}]]}}"> Init.</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_init" title="%{pnj_init} Jet d'Initiative" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init}[Init.] + @{pnj_init_var}[Dé(s)] &{tracker}]]}}"> Init.</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_init" type="number" title="@{pnj_init}" />
                 </div>
@@ -1685,7 +1685,7 @@
             <table class="sheet-tabsep">
               <tr>
                 <td style="width: 30px;">
-                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
+                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" title="%{repeating_pnjatk_$N_jet} Jet d'attaque PNJ" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
                 </td>
                 <td class="sheet-boxinputleft" style="width: 250px;">
                   <input type="checkbox" name="attr_atkatt" title="@{atkatt} Faire un jet d'attaque pour toucher" value="attaque=" checked="checked" />
@@ -1743,7 +1743,7 @@
             <table class="sheet-tabsep">
               <tr>
                 <td style="width: 30px;">
-                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{capanom}}} {{text=@{capadesc}}}" />
+                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" title="%{repeating_pnjcapas_$N_jet} Jet de capacité PNJ" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{capanom}}} {{text=@{capadesc}}}" />
                 </td>
                 <td class="sheet-boxinputleft" style="width: 200px;">
                   <input type="text" class="sheet-carac" style="width: 200px;" name="attr_capanom" title="@{capanom} Nom de la capacité" />

--- a/coc.html
+++ b/coc.html
@@ -158,7 +158,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_FOR" title="Jet de Force" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_for" title="Jet de Force" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_FOR_SUP" title="@{FOR_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -182,7 +182,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_DEX" title="Jet de Dextérité" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]]}}"> DEX</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_dex" title="Jet de Dextérité" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]]}}"> DEX</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_DEX_SUP" title="@{DEX_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -206,7 +206,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_CON" title="Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]]}}"> CON</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_con" title="Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]]}}"> CON</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_CON_SUP" title="@{CON_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -230,7 +230,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_INT" title="Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]]}}"> INT</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_int" title="Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]]}}"> INT</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_INT_SUP" title="@{INT_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -254,7 +254,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_PER" title="Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]]}}"> PER</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_per" title="Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]]}}"> PER</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_PER_SUP" title="@{PER_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -278,7 +278,7 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button class="sheet-boxtitre" type="roll" name="JET_CHA" title="Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]]}}"> CHA</button>
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_cha" title="Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]]}}"> CHA</button>
                   </td>
                   <td class="sheet-boxinputlight">
                     <select class="sheet-selectmin" name="attr_CHA_SUP" title="@{CHA_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
@@ -373,7 +373,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="JET_CAC" title="Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]]}}"> AU CONTACT</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_cac" title="Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]]}}"> AU CONTACT</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKCAC_BASE" value="0" title="@{ATKCAC_BASE} Score de base" />
@@ -397,7 +397,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="JET_TIR" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]]}}"> &Agrave; DISTANCE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_tir" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]]}}"> &Agrave; DISTANCE</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKTIR_BASE" value="0" title="@{ATKTIR_BASE} Score de base" />
@@ -421,7 +421,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="JET_MEN" title="Jet d'attaque mentale" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Mental}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMEN}]][Bonus] ]]}}"> MENTAL</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_men" title="Jet d'attaque mentale" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Mental}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMEN}]][Bonus] ]]}}"> MENTAL</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKMEN_BASE" value="0" title="@{ATKMEN_BASE} Score de base" />
@@ -445,7 +445,7 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="JET_MAG" title="Jet d'attaque magique" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Magique}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMAG}]][Bonus] ]]}}"> MAGIQUE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_mag" title="Jet d'attaque magique" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Magique}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKMAG}]][Bonus] ]]}}"> MAGIQUE</button>
                         </td>
                         <td class="sheet-boxinput">
                           <input type="number" name="attr_ATKMAG_BASE" value="0" title="@{ATKMAG_BASE} Score de base" />
@@ -469,10 +469,10 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="attr_JET_INIT" title="@{JET_INIT} Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT_JET} &{tracker}]]}}"> INITIATIVE</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_jet_init" title="@{JET_INIT} Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT_JET} &{tracker}]]}}"> INITIATIVE</button>
                         </td>
                         <td class="sheet-boxtitre">
-                          <button class="sheet-boxtitre" type="roll" name="attr_NEXT_INIT" title="@{NEXT_INIT} Actions multiples si jet d'Init > 20, 30, etc..." value="@{togm}&{template:co1} {{perso=@{selected|character_name}}} {{subtags=Initiative}} {{name=Action suivante}} {{desc=(A)ction / (M)ouvement à Init-[[10 &{tracker:-}]]}}"> Suite</button>
+                          <button class="sheet-boxtitre" type="roll" name="roll_next_init" title="@{NEXT_INIT} Actions multiples si jet d'Init > 20, 30, etc..." value="@{togm}&{template:co1} {{perso=@{selected|character_name}}} {{subtags=Initiative}} {{name=Action suivante}} {{desc=(A)ction / (M)ouvement à Init-[[10 &{tracker:-}]]}}"> Suite</button>
                         </td>
                         <td class="sheet-boxinputlight">
                           <input type="number" name="attr_INIT_CARAC" title="@{INIT_CARAC}" value="@{DEXTERITE}" disabled />
@@ -621,7 +621,7 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td>
-                    <button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
+                    <button type="roll" class="sheet-neutre" name="roll_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
                     <!-- original : "@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}  @{armelim}}} {{portee=@{armeportees}}} {{desc=@{armejetn}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + ([[@{visee_att}]])[Tir visé] + ([[@{distance}]])[Portée] ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + ([[@{visee_dm}]])[Tir visé] ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" -->
                   </td>
                   <td class="sheet-boxinputleft" style="min-width:125px;">
@@ -1024,7 +1024,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td>
-                <button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
+                <button type="roll" class="sheet-neutre" name="roll_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
               </td>
               <td class="sheet-boxinputleft" style="min-width:200px;">
                 <input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;" placeholder="Nom du Jet de capacité" />
@@ -1102,7 +1102,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td style="width: 15px;">
-                <button type="roll" name="attr_chat" class="sheet-output" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
+                <button type="roll" name="roll_trait" class="sheet-output" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
               </td>
               <td class="sheet-boxinputleft" style="width: 200px;">
                 <input type="text" style="font-weight: bold;" name="attr_traitnom" placeholder="Nom du trait" title="@{traitnom}" />
@@ -1146,10 +1146,10 @@
             <table class="sheet-tabsep">
               <tr>
                 <td class="sheet-boxtitre">
-                  <button type="roll" class="sheet-boxtitre" title="Utilisation d'un PC" name="attr_JET_PC" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{PC_DESC}}} {{subtags=Bonus}} {{desc=@{character_name} utilise un @{PC_DESC} et obtient un bonus de @{PC_BONUS}}}" /> PC
+                  <button type="roll" class="sheet-boxtitre" title="Utilisation d'un PC" name="roll_jet_pc" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{PC_DESC}}} {{subtags=Bonus}} {{desc=@{character_name} utilise un @{PC_DESC} et obtient un bonus de @{PC_BONUS}}}" /> PC
                 </td>
                 <td class="sheet-boxtitre">
-                  <button type="roll" class="sheet-boxtitre" title="Jet de Récupération" name="attr_JET_PR" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalité}} {{DV=[[1d@{DV}[Dé de Vie] +[[@{CON}]][CON] +@{NIVEAU}[Niveau] ]]}}" /> PR</td>
+                  <button type="roll" class="sheet-boxtitre" title="Jet de Récupération" name="roll_jet_pr" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalité}} {{DV=[[1d@{DV}[Dé de Vie] +[[@{CON}]][CON] +@{NIVEAU}[Niveau] ]]}}" /> PR</td>
                 <td class="sheet-boxtitre">PM</td>
               </tr>
               <tr>
@@ -1393,7 +1393,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td class="sheet-boxtitre">
-                <button class="sheet-boxtitre" type="roll" name="JET_PSI" title="Jet d'attaque PSI" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=PSI}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSI}]][Bonus] ]]}}"> Attaque PSI</button>
+                <button class="sheet-boxtitre" type="roll" name="roll_jet_psi" title="Jet d'attaque PSI" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=PSI}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSI}]][Bonus] ]]}}"> Attaque PSI</button>
               </td>
               <td class="sheet-boxinput">
                 <input type="number" name="attr_ATKPSI_BASE" value="0" title="@{ATKPSI_BASE}" />
@@ -1482,7 +1482,7 @@
         <table class="sheet-tabsep">
           <tr>
             <td>
-              <button type="roll" class="sheet-neutre" name="attr_jetv" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetvnom}}} {{subtags=@{VEHICULE}}} {{carac=[[@{jetvnbde}d@{jetvde}@{jetvtypjet} + [[@{jetvcaracp}]][Bonus] + [[@{jetvcarac}]][Véhicule] + @{jetvdiv}[Divers] ]]}} {{desc=@{jetvdesc}}}" />
+              <button type="roll" class="sheet-neutre" name="roll_jetv" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetvnom}}} {{subtags=@{VEHICULE}}} {{carac=[[@{jetvnbde}d@{jetvde}@{jetvtypjet} + [[@{jetvcaracp}]][Bonus] + [[@{jetvcarac}]][Véhicule] + @{jetvdiv}[Divers] ]]}} {{desc=@{jetvdesc}}}" />
             </td>
             <td class="sheet-boxinputleft" style="min-width:200px;">
               <input type="text" name="attr_jetvnom" title="@{jetvnom}" style="font-weight: bold;" placeholder="Nom du Jet de véhicule" />
@@ -1564,7 +1564,7 @@
             <div class="sheet-3colrow">
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_for" title="Jet de Force" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{pnj_jetfor}cs20cf1[Dé] + [[@{pnj_for}]][FOR] ]] }}"> FOR</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_for" title="Jet de Force" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{pnj_jetfor}cs20cf1[Dé] + [[@{pnj_for}]][FOR] ]] }}"> FOR</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_for" type="number" title="@{pnj_for}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetfor" title="@{pnj_jetfor}">
@@ -1575,7 +1575,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_dex" title="Jet de Dextérité" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{pnj_jetdex}cs20cf1[Dé] + [[@{pnj_dex}]][DEX] ]] }}"> DEX</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_dex" title="Jet de Dextérité" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{pnj_jetdex}cs20cf1[Dé] + [[@{pnj_dex}]][DEX] ]] }}"> DEX</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_dex" type="number" title="@{pnj_dex}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetdex" title="@{pnj_jetdex}">
@@ -1586,7 +1586,7 @@
               </div>
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_con" title="Jet de Constitution" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{pnj_jetcon}cs20cf1[Dé] + [[@{pnj_con}]][CON] ]] }}"> CON</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_con" title="Jet de Constitution" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{pnj_jetcon}cs20cf1[Dé] + [[@{pnj_con}]][CON] ]] }}"> CON</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_con" type="number" title="@{pnj_con}" />
                   <select class="sheet-carac" style="width: 30px;" size="1" name="attr_pnj_jetcon" title="@{pnj_jetcon}">
@@ -1636,7 +1636,7 @@
             <div class="sheet-3colrow">
               <div class="sheet-col" style="width: 27%;">
                 <div class="sheet-boxtitre">
-                  <button class="sheet-boxtitre" type="roll" name="jet_pnj_init" title="Jet d'Initiative" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init}[Init.] + @{pnj_init_var}[Dé(s)] &{tracker}]]}}"> Init.</div>
+                  <button class="sheet-boxtitre" type="roll" name="roll_pnj_init" title="Jet d'Initiative" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init}[Init.] + @{pnj_init_var}[Dé(s)] &{tracker}]]}}"> Init.</div>
                 <div class="sheet-boxinput">
                   <input class="sheet-carac" name="attr_pnj_init" type="number" title="@{pnj_init}" />
                 </div>
@@ -1685,7 +1685,7 @@
             <table class="sheet-tabsep">
               <tr>
                 <td style="width: 30px;">
-                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="attr_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
+                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
                 </td>
                 <td class="sheet-boxinputleft" style="width: 250px;">
                   <input type="checkbox" name="attr_atkatt" title="@{atkatt} Faire un jet d'attaque pour toucher" value="attaque=" checked="checked" />
@@ -1743,7 +1743,7 @@
             <table class="sheet-tabsep">
               <tr>
                 <td style="width: 30px;">
-                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="attr_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{capanom}}} {{text=@{capadesc}}}" />
+                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{capanom}}} {{text=@{capadesc}}}" />
                 </td>
                 <td class="sheet-boxinputleft" style="width: 200px;">
                   <input type="text" class="sheet-carac" style="width: 200px;" name="attr_capanom" title="@{capanom} Nom de la capacité" />
@@ -2186,13 +2186,14 @@
     }
     
     return result;
-  }
+  };
 
   function buildCaracs() {
     getAttrs([
       'FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU',
       'RANG_VOIE1', 'RANG_VOIE2', 'RANG_VOIE3', 'RANG_VOIE4', 'RANG_VOIE5', 'RANG_VOIE6', 'RANG_VOIE7', 'RANG_VOIE8', 'RANG_VOIE9',
-      'voie1nom', 'voie2nom', 'voie3nom', 'voie4nom', 'voie5nom', 'voie6nom', 'voie7nom', 'voie8nom', 'voie9nom'
+      'voie1nom', 'voie2nom', 'voie3nom', 'voie4nom', 'voie5nom', 'voie6nom', 'voie7nom', 'voie8nom', 'voie9nom',
+      'DEFARMUREON'
     ], function(values) {
       let caracs = {
         FOR: 0,
@@ -2210,7 +2211,10 @@
         if (car.startsWith('RANG_')) {
           if (!caracs.hasOwnProperty('rangs')) caracs.rangs = [0, 0, 0, 0, 0, 0, 0, 0, 0];
           let voie = parseInt(car.substring(car.length - 1)) || 0;
-          if (voie > 0) caracs.rangs[voie - 1] = vcar;
+          if (voie > 0) {
+            caracs[car] = vcar;
+            caracs.rangs[voie - 1] = vcar;
+          }
         } else if (car.startsWith('voie') && car.endsWith('nom')) {
           if (!caracs.hasOwnProperty('voies')) caracs.voies = ['', '', '', '', '', '', '', '', ''];
           let voie = parseInt(car.substring(4, 5)) || 0;
@@ -2399,8 +2403,10 @@
     buildCaracs();
   });
 
+  
   function buffValue(v, caracs) {
     v = v.trim();
+    let bv = 0;
     let bm = 1;
     if (v.startsWith('-')) bm = -1;
     if (v.indexOf('2[') !== -1) {
@@ -2410,11 +2416,11 @@
     v = v.replace(/[\+\-\[\]]/g, '');
     if (isNaN(v)) {
       // c'est une référence d'attribut
-      if (v.toUpperCase().startsWith('VOIE')) {
+      if (v.length === 5 && v.toUpperCase().startsWith('VOIE')) {
         // c'est un rang dans une voie identifiée par son no
         let rv = parseInt(v.substring(4).trim()) || 0;
         if (rv > 0) bv = caracs.rangs[rv - 1];
-      } else if (v.toUpperCase().startsWith('RANG')) {
+      } else if (v.toUpperCase().startsWith('RANG ')) {
         // c'est un rang dans une voie identifiée par son nom
         let vname = v.substring(4).trim().toUpperCase();
         let vfound = -1;
@@ -2426,8 +2432,17 @@
         }
         if (vfound > -1) bv = caracs.rangs[vfound];
       } else {
-        // c'est un mod. de carac
-        bv = caracs[v];
+        if (caracs.hasOwnProperty(v)) {
+          // c'est un mod. de carac
+          bv = caracs[v];
+        } else {
+          // c'est une expression numérique
+          for (let attr of Object.keys(caracs)) {
+            let re = new RegExp(`${attr}`,'g');
+            v = v.replace(re, 'caracs[\'$&\']');
+          }
+          bv = eval(v);
+        }
       }
     } else { // c'est une valeur fixe
       bv = v;
@@ -2458,9 +2473,6 @@
               buffName = buffv[0].trim();
               buffVal = buffValue(buffv[1], caracs);
             }
-            consoleLog(buff);
-            consoleLog(buffName);
-            consoleLog(buffVal);
             if (!buffName.startsWith('-')) buffSum += buffVal;
           }
         }
@@ -2473,29 +2485,33 @@
 
   function updateBuffs(e) {
     const caracs = ['FOR', 'DEX', 'CON', 'INT', 'PER', 'CHA'];
-    let mod = e.sourceAttribute.substring(0, 3).toUpperCase();
-    if (!caracs.includes(mod)) return;
-    const attrs = [...caracs, 'ATKCAC', 'ATKTIR', 'ATKMAG', 'ATKMEN', 'INIT', 'DEF'];
+    let ref = e.sourceAttribute;
+    let mod = ref.substring(0, 3);
+    if (caracs.includes(mod.toUpperCase())) ref = mod;
+    const attrs = [...caracs, 'ATKCAC', 'ATKTIR', 'ATKMAG', 'ATKMEN', 'INIT', 'DEF', 'PV'];
     for (let a = 0; a < attrs.length; a++) {
       attrs[a] = `${attrs[a]}_BUFF_LIST`;
     }
-    attrs.unshift(mod);
+    attrs.unshift(ref);
     getAttrs(attrs, function(values) {
       let props = Object.keys(values);
       for (let p = 1; p < props.length; p++) {
-        if (props[p].startsWith(props[0])) continue;
-        if (values[props[p]].indexOf(`[${props[0]}]`) !== -1) parseBuff(props[p].replace('_BUFF_LIST', ''));
+        let ref = props[0];
+        if (props[p].startsWith(ref)) continue;
+        if (values[props[p]].toLowerCase().indexOf(ref) !== -1) {
+          parseBuff(props[p].replace('_BUFF_LIST', ''));
+        }
       }
     });
-  }
+  };
 
   function changeCaracs() {
-    let changeCaracs = '';
-    const caracs = ['FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU'];
+    let changedCaracs = '';
+    const caracs = ['FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU', 'DEFARMUREON'];
     for (let c = 0; c < caracs.length; c++) {
-      changeCaracs += `change:${caracs[c]} `;
+      changedCaracs += `change:${caracs[c].toLowerCase()} `;
     }
-    return changeCaracs;
+    return changedCaracs;
   }
 
   on(changeCaracs(), function(eventInfo) {
@@ -2505,6 +2521,16 @@
     updateBuffs(eventInfo);
   });
 
+/*
+  const caracs = ['FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU', 'DEFARMUREON'];
+
+  on(`change:${caracs.join(' change:').toLowerCase()}`,(eventInfo) => {
+    // on reconstruit d'abord l'attribut caché CARACS...
+    buildCaracs();
+    // ... puis on met à jour les buffs qui contiennent une référence à la caractéristique modifiée
+    updateBuffs(eventInfo);
+  });
+*/
   on('change:for_buff_list', function() {
     parseBuff('FOR');
   });
@@ -3295,7 +3321,7 @@
   on('clicked:dv', function() {
     getAttrs(['NIVEAU'], function(value) {
       let niveau = parseInt(value.NIVEAU) || 0;
-      if (niveau > 0 && niveau <=20) {
+      if (niveau > 0 && niveau <= 20) {
         setAttrs({
           NIVEAU: niveau + 1
         });


### PR DESCRIPTION
@Ulty 

**Fiche PJ, onglet Configuration**
- Ajout d'un champ de buff pour les PV
- Ajout d'un sélecteur pour le mode de calcul des points de vie (lancer le DV ou utiliser la valeur moyenne du DV)

**Fiche PJ, onglet Caractéristiques**
- Modification du roll-button de lancement de dé de vie en action-button permettant d'augmenter le niveau de 1
- Ajout d'un script sheet-worker pour recalculer / lancer les points de vie lorsque le niveau, le mod de constitution, le buff de PV ou le mode de calcul des PV est modifié

**Modifications globales**
Modification des attributs name de tous les roll-buttons en "roll_nomJet" et ajout des attributs title
- Permet d'invoquer un jet de dés de la fiche de personnage depuis le chat en indiquant %{selected|nomJet} (si un token est sélectionné) ou %{nomPerso|nomJet}
- Permet d'afficher le nom du jet qui peut être utilisé dans le chat ou les macros